### PR TITLE
add grid columns for right space

### DIFF
--- a/unlockopen.css
+++ b/unlockopen.css
@@ -413,7 +413,7 @@ div[class^="slide-grid"] {
 
 .emoji {
   grid-row: emoji;
-  grid-column: 1 / -1;
+  grid-column: 1 / -2;
   justify-self: center;
   align-self: end;
   margin-bottom: var(--space-xs);
@@ -423,7 +423,7 @@ div[class^="slide-grid"] {
 
 .content {
   grid-row: main-content;
-  grid-column: 1 / -1;
+  grid-column: 1 / -2;
   display: grid;
   grid-template-columns: subgrid;
   width: 830px;
@@ -434,7 +434,6 @@ div[class^="slide-grid"] {
 
 .full-width {
   grid-column: 1 / -1;
-	max-inline-size: 50ch;
 }
 
 .left {
@@ -443,7 +442,7 @@ div[class^="slide-grid"] {
 }
 
 .right {
-  grid-column: 4 / -2;
+  grid-column: 4 / -1;
   text-align: left;
 }
 

--- a/unlockopen.css
+++ b/unlockopen.css
@@ -334,7 +334,7 @@ section[data-markdown]:not([data-background-image]) {
 div[class^="slide-grid"] {
   position: relative;
   display: grid !important;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(7, 1fr);
   grid-template-rows: [emoji] 10rem [main-content] auto [bottom-content] max-content [footer] max-content;
   width: 960px;
   height: 100%;
@@ -438,12 +438,12 @@ div[class^="slide-grid"] {
 }
 
 .left {
-  grid-column: 1 / 3;
+  grid-column: 1 / 4;
   text-align: left;
 }
 
 .right {
-  grid-column: 3 / -1;
+  grid-column: 4 / -2;
   text-align: left;
 }
 

--- a/unlockopen.css
+++ b/unlockopen.css
@@ -437,7 +437,6 @@ div[class^="slide-grid"] {
 }
 
 .full-width > *:not(h1, h2) {
-  grid-column: 1 / -1;
   max-inline-size: 50ch;
 }
 

--- a/unlockopen.css
+++ b/unlockopen.css
@@ -413,7 +413,7 @@ div[class^="slide-grid"] {
 
 .emoji {
   grid-row: emoji;
-  grid-column: 1 / -2;
+  grid-column: 1 / -1;
   justify-self: center;
   align-self: end;
   margin-bottom: var(--space-xs);
@@ -423,7 +423,7 @@ div[class^="slide-grid"] {
 
 .content {
   grid-row: main-content;
-  grid-column: 1 / -2;
+  grid-column: 1 / -1;
   display: grid;
   grid-template-columns: subgrid;
   width: 830px;
@@ -436,13 +436,18 @@ div[class^="slide-grid"] {
   grid-column: 1 / -1;
 }
 
+.full-width > *:not(h1, h2) {
+  grid-column: 1 / -1;
+  max-inline-size: 50ch;
+}
+
 .left {
   grid-column: 1 / 4;
   text-align: left;
 }
 
 .right {
-  grid-column: 4 / -1;
+  grid-column: 4 / -2;
   text-align: left;
 }
 


### PR DESCRIPTION
Only the split layout is using the template columns for now. I extended them to 7, the last row is kept empty, creating a similar empty space than full-width. 