### PR TITLE
Add content offset in the size of the logo icon

### DIFF
--- a/unlockopen.css
+++ b/unlockopen.css
@@ -86,6 +86,7 @@
   --theme-color-dark: var(--color-grey-dark);
 	--opacity-4: 0.4;
 	--opacity-3: 0.3;
+	--logo-icon: 2.8rem;
 }
 
 .theme-pink {
@@ -459,6 +460,7 @@ div[class^="slide-grid"] {
 
 .full-width {
   grid-column: 1 / -1;
+	margin-left: var(--logo-icon);
 }
 
 .full-width > *:not(h1, h2) {
@@ -468,6 +470,7 @@ div[class^="slide-grid"] {
 .left {
   grid-column: 1 / 4;
   text-align: left;
+	margin-left: var(--logo-icon);
 }
 
 .right {


### PR DESCRIPTION
The idea is to use the same content-offset we have on the website: aligned to the beginning of the logo text. Goes for print and regular slides. 